### PR TITLE
Add AeState to stable LIBCAMERA_CONTROL block

### DIFF
--- a/device/libcamera/options.cc
+++ b/device/libcamera/options.cc
@@ -50,10 +50,10 @@ static std::map<unsigned, libcamera_control_id_t> libcamera_control_ids =
   LIBCAMERA_CONTROL(AfSpeed, "AfSpeed"),
   LIBCAMERA_CONTROL(AfTrigger, "AfTrigger"),
   LIBCAMERA_CONTROL(AfState, "AfState"),
+  LIBCAMERA_CONTROL(AeState, "AeState"),
   LIBCAMERA_DRAFT_CONTROL(AePrecaptureTrigger),
   LIBCAMERA_DRAFT_CONTROL(NoiseReductionMode),
   LIBCAMERA_DRAFT_CONTROL(ColorCorrectionAberrationMode),
-  LIBCAMERA_DRAFT_CONTROL(AeState),
   LIBCAMERA_DRAFT_CONTROL(AwbState),
   LIBCAMERA_DRAFT_CONTROL(LensShadingMapMode),
 #if LIBCAMERA_VERSION_MAJOR == 0 && LIBCAMERA_VERSION_MINOR < 1 // Support RasPI bullseye


### PR DESCRIPTION
Moved AeState from the draft control list to the stable control block.