### PR TITLE
libcamera_parse_control_value(): Fix splitting options by coma. Also decode POST arguments.

### DIFF
--- a/util/http/http.h
+++ b/util/http/http.h
@@ -4,6 +4,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <ctype.h>
 #include <pthread.h>
 #include <netinet/ip.h>
 


### PR DESCRIPTION
libcamera_parse_control_value() splits options by coma which makes sense for many options but it mishandles options like:
"AfWindows=(1152,1296)/2304x1296" or "ScalerCrop=(0,0)/4608x2592".

Example:
`
./camera-streamer  --camera-path=/base/soc/i2c0mux/i2c@1/imx708@1a --camera-type=libcamera --camera-options="AfWindows=(1152,1296)/2304x1296" 2>&1 |grep AfWindows device/libcamera/options.cc: CAMERA: Configuring option 'AfWindows' (00000025, type=9) = [ (0, 0)/0x0, (0, 0)/0x0 ]
`

It parsed option incorrectly end got wrong [ (0, 0)/0x0, (0, 0)/0x0 ] result.

Same for ScalerCrop:
`
./camera-streamer  --camera-path=/base/soc/i2c0mux/i2c@1/imx708@1a --camera-type=libcamera --camera-options="ScalerCrop=(0,0)/4608x2592" 2>&1 |grep ScalerCrop device/libcamera/options.cc: CAMERA: Configuring option 'ScalerCrop' (0000001b, type=9) = [ (0, 0)/0x0, (0, 0)/0x0 ]
`

With fix options are parsed and interpreted correctly:

`
./camera-streamer  --camera-path=/base/soc/i2c0mux/i2c@1/imx708@1a --camera-type=libcamera --camera-options="AfWindows=(1152,1296)/2304x1296" 2>&1 |grep AfWindows device/libcamera/options.cc: CAMERA: Configuring option 'AfWindows' (00000025, type=9) = (1152, 1296)/2304x1296
`

so expected  (1152, 1296)/2304x1296

`
./camera-streamer  --camera-path=/base/soc/i2c0mux/i2c@1/imx708@1a --camera-type=libcamera --camera-options="ScalerCrop=(0,0)/4608x2592" 2>&1 |grep ScalerCrop device/libcamera/options.cc: CAMERA: Configuring option 'ScalerCrop' (0000001b, type=9) = (0, 0)/4608x2592
`

and also expected (0, 0)/4608x2592

Fixes https://github.com/ayufan/camera-streamer/issues/114


Also decode POST arguments, so if you set option like ScalerCrop fro web UI you will get it correctly applied.
For example set via web ui: ScalerCrop to (964,436)/3000x1920

With fix:
`
util/http/http.c: HTTP8080/5: Request 'POST' '/option' 'device=CAMERA&key=scalercrop&value=(964%2C436)%2F3000x1920'
device/libcamera/options.cc: CAMERA: Configuring option 'ScalerCrop' (0000001b, type=9) = (964, 436)/3000x1920
`

Fixes https://github.com/ayufan/camera-streamer/issues/115